### PR TITLE
making compatible with php-integrator ~0.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "php-integrator-symbol-viewer",
   "main": "./lib/Main",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "description": "Atom package providing side panel with class information.",
   "repository": "https://github.com/tocjent/php-integrator-symbol-viewer.git",
   "license": "GPL-3.0",
@@ -11,7 +11,7 @@
   "consumedServices": {
     "php-integrator.service": {
       "versions": {
-        "~0.7.0": "init"
+        "~0.8.0": "init"
       }
     }
   },


### PR DESCRIPTION
The changes of 0.8.0 may not impact in the main functionality
of this project. And this according to @Gert-dev on issue #30.