### PR TITLE
fix of the duplicating empty message

### DIFF
--- a/lib/EmptyFiguresView.js
+++ b/lib/EmptyFiguresView.js
@@ -1,7 +1,7 @@
 'use babel';
 
 module.exports = function FiguresView(figuresModel) {
-    var container = document.createElement('atom-php-integrator-symbol-viewer');
+    var container = document.createElement('atom-php-integrator-symbol-viewer-content');
     container.innerHTML = `
         <div class="empty-view-container">
             <div class="empty-view-title">


### PR DESCRIPTION
Added `-content` to the end of the `document.createElement` function in `EmptyFiguresViews.js`, since it was creating the full sidebar over and over again. This change made it so the empty message doesn't duplicate itself when you switch between files that don't have PHP classes/methods.